### PR TITLE
apt-get fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ VOLUME ["/var/lib/samba", "/etc/samba"]
 # - expect, pwgen: utilities needed for setup
 # - sssd: for UNIX logins to AD
 RUN [ -n "$APT_ARCHIVE" ] && sed -e "s/archive\./$APT_ARCHIVE.archive./" /etc/apt/sources.list -i; true
-RUN export http_proxy="$APT_PROXY" && apt-get update && apt-get upgrade && apt-get install -y \
+RUN export http_proxy="$APT_PROXY" && apt-get update && apt-get install -y \
   ntp supervisor \
   krb5-user krb5-kdc bind9 psmisc dnsutils \
   attr acl python-dnspython python-xattr \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM ubuntu:trusty
 MAINTAINER Ernad Husremovic <hernad@bring.out.ba> 
 # Thank you: Martin Yrj√∂l√<martin.yrjola@gmail.com> & Tobias Kaatz <info@kaatz.io>
 
+ARG APT_ARCHIVE
+ARG APT_PROXY
+
 ENV DEBIAN_FRONTEND noninteractive
 
 VOLUME ["/var/lib/samba", "/etc/samba"]
@@ -9,8 +12,8 @@ VOLUME ["/var/lib/samba", "/etc/samba"]
 # Update Ubuntu and install dependencies:
 # - expect, pwgen: utilities needed for setup
 # - sssd: for UNIX logins to AD
-RUN sed -e 's/archive./ba.archive./' /etc/apt/sources.list -i
-RUN apt-get update && apt-get upgrade && apt-get install -y \
+RUN [ -n "$APT_ARCHIVE" ] && sed -e "s/archive\./$APT_ARCHIVE.archive./" /etc/apt/sources.list -i; true
+RUN export http_proxy="$APT_PROXY" && apt-get update && apt-get upgrade && apt-get install -y \
   ntp supervisor \
   krb5-user krb5-kdc bind9 psmisc dnsutils \
   attr acl python-dnspython python-xattr \

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # Docker container demonstrating Samba's Active Directory Domain Controller (AD DC) support
 
-Run these commands to start the container
+## Build
+
+Build the image with this command:
 ```
 docker build -t samba-ad-dc .
+```
+
+For faster builds, you may override the Ubuntu mirror by adding `--build-arg APT_ARCHIVE=ba`, or point `apt-get` to use a proxy with `--build-arg APT_PROXY=http://squid-deb-proxy.local:8000`
+
+## Run
+
+Run this command to start the container:
+```
 docker run --privileged -v ${PWD}/samba:/var/lib/samba  -e "SAMBA_DOMAIN=samdom" -e "SAMBA_REALM=samdom.example.com" --name dc1 --dns 127.0.0.1 -d samba-ad-dc
 ```
 You can of course change the domain and realm to your liking.


### PR DESCRIPTION
This PR addresses several concerns:
1. Running `apt-get update` on a single line is discouraged due to caching issues (see https://docs.docker.com/v1.8/articles/dockerfile_best-practices/#run).
2. Running `apt-get upgrade` is also discouraged (see the same document).
3. Using hard-coded http://ba.archive.ubuntu.com is not friendly to users from other countries (I reworked `Dockerfile` to accept `--build-arg APT_ARCHIVE=ba` to achieve the same result).
4. I added an (optional) way to utilize `squid-deb-proxy` for faster builds.
